### PR TITLE
change mkdoc default type to Organization

### DIFF
--- a/arguments.js
+++ b/arguments.js
@@ -60,8 +60,8 @@ exports.getArgs = function getArgs() {
   });
   mkdoc.addArgument(['-t', '--type'], {
     action: 'store',
-    defaultValue: 'Folder',
-    help: 'Nuxeo Document Type (default: Folder)'
+    defaultValue: 'Organization',
+    help: 'Nuxeo Document Type (default: Organization -- this is the usual value for folder objects)'
   });
   mkdoc.addArgument( [ '-f', '--force' ], {
     action: 'storeTrue',


### PR DESCRIPTION
Previous default value of "Folder" caused issues with Calisphere harvesting when type not explicitly set as "Organization." Since "Organization" is the usual value we want for folder objects in Nuxeo, it makes sense that it be the default value here.